### PR TITLE
Update cb.js

### DIFF
--- a/lib/cb.js
+++ b/lib/cb.js
@@ -492,7 +492,7 @@ var updateOneDoc = function(thisRef,myBucket,idkey,model,inboundData,callback){
 
 	myBucket.get(idkey,function(err, result) {
 		if(err){
-			debug("    CouchbaseDB   updateOneDoc()  : Can not find the document with the id  '"  + id + "'" );
+			debug("    CouchbaseDB   updateOneDoc()  : Can not find the document with the id  '"  + idkey + "'" );
 			callback(err,null);
 			return;
 		}


### PR DESCRIPTION
Was throwing the following error when attempting to do a `model.updateAttributes` with an invalid id.

```
...\loopback-connector-couchbase\lib\cb.js:495
                        debug("    CouchbaseDB   updateOneDoc()  : Can not find the document with the id  '"  + id + "'" );
                                                                                                                ^

ReferenceError: id is not defined
    at ...\loopback-connector-couchbase\lib\cb.js:495:92
```

Now it returns a proper error instead, in the (error, result) callback.
